### PR TITLE
Remove custom labelling in favour of native github action

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,6 @@ const isChangesetExisting = async (githubToken, localePath, checkName) => {
       });
     } else {
       const changeset = getChangeset(localeFiles, localePath);
-      const labelName = "translations";
 
       let translationKeysContainValues = Object.create({
         ...Object.keys(changeset),
@@ -113,39 +112,6 @@ const isChangesetExisting = async (githubToken, localePath, checkName) => {
           },
         });
       } else {
-        // Create label if it doesn't exist, add it if it already exists
-        octokit.rest.issues
-          .getLabel({
-            owner,
-            repo,
-            name: labelName,
-          })
-          .then((res) => {
-            octokit.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number: prNumber,
-              labels: [labelName],
-            });
-          })
-          .catch((res) => {
-            octokit.rest.issues
-              .createLabel({
-                owner,
-                repo,
-                name: labelName,
-                description: "PR is lacking translations",
-              })
-              .then((res) => {
-                octokit.rest.issues.addLabels({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                  labels: [labelName],
-                });
-              });
-          });
-
         let localesWithMissingValues = Object.create({
           ...Object.keys(changeset),
         });


### PR DESCRIPTION
Let's just use the native github action for labelling, it's much simpler and more intuitive - https://github.com/e-conomic/frontend-template/blob/main/.github/labeler.yml.